### PR TITLE
Bump enonic libs for XP 8

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 thymeleaf = "3.0.0-SNAPSHOT"
-util = "3.1.1"
+util = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }


### PR DESCRIPTION
## Summary

Bumps the Enonic lib SNAPSHOT pins published from the libs' XP 8 master branches. We are not releasing these libs yet, so consumers pin directly to the SNAPSHOTs from the Enonic dev repo.

| lib | before | after |
| --- | --- | --- |
| `com.enonic.lib:lib-util` | `3.1.1` | `4.0.0-SNAPSHOT` *(dev repo)* |

`lib-menu` and `lib-explorer` are not consumed by this app, so only `lib-util` was bumped.

## Excludes audit

No `exclude` clauses exist on any Enonic lib dependency in this repo — there was nothing to clean up. The resolved `include` configuration stays clean:

```
\--- com.enonic.lib:lib-util:4.0.0-SNAPSHOT
```

## Snapshot repo

The dev/snapshot Maven repo (`xp.enonicRepo("dev")`) is already declared in `build.gradle` from the prior XP 8 upgrade, so no repository change was needed.

## Verification

- `./gradlew clean build` — green.
- Runtime verification (deploying into a running XP 8 instance) was **not** performed.

## Test plan

- [ ] CI build passes on the new branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)