### PR TITLE
Bump version to 3.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Gradle Project settings
 projectName = sumome
-version=2.1.0-SNAPSHOT
+version=3.0.0-SNAPSHOT
 
 # XP App values
 appName = com.enonic.app.sumome


### PR DESCRIPTION
## Summary
- Branch out `2.x` maintenance line at the post-release SNAPSHOT commit (`6d32620`).
- Bump master to `3.0.0-SNAPSHOT` for XP 8.
- Add `releaseBranch:` block to `enonic-gradle.yml` listing both `master` and `2.x` so pushes to either are recognized as release-branch builds.

Reference: app-booster (compare master and 1.x).

## Test plan
- [x] `gradle.properties` shows `version=3.0.0-SNAPSHOT`
- [x] Workflow lists `master` and `2.x` under `releaseBranch:`
- [ ] CI green on this branch