### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -1,0 +1,29 @@
+name: Gradle Build
+
+on: [ push ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.build-and-publish.outputs.release }}
+    steps:
+      - id: build-and-publish
+        uses: enonic/release-tools/build-and-publish@master
+        with:
+          repoUser: ci
+          repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
+
+  release:
+    runs-on: ubuntu-latest
+
+    needs: build
+    if: needs.build.outputs.release == 'true'
+
+    steps:
+      - uses: enonic/release-tools/release@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `.github/workflows/enonic-gradle.yml` to the `2.x` maintenance branch.
- Workflow lists both `master` and `2.x` under `releaseBranch:` so pushes to `2.x` are recognized as release-branch builds (the action reads `releaseBranch:` from the branch's own workflow file).

No version bump, no other changes — those are master-only per app-booster's reference (compare master vs 1.x).

## Test plan
- [x] Workflow lists `master` and `2.x` under `releaseBranch:`
- [ ] After merge: a CI run on `2.x` classifies it as a release branch