### PR TITLE
Drop lib-util

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ dependencies {
     implementation xplibs.api.portal
     include xplibs.portal
     include libs.lib.thymeleaf
-    include libs.lib.util
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,5 @@
 [versions]
 thymeleaf = "3.0.0-SNAPSHOT"
-util = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }
-lib-util = { module = "com.enonic.lib:lib-util", version.ref = "util" }

--- a/src/main/resources/cms/processors/sumome-script.js
+++ b/src/main/resources/cms/processors/sumome-script.js
@@ -1,6 +1,5 @@
 var libPortal = require('/lib/xp/portal');
 var libThymeleaf = require('/lib/thymeleaf');
-var libUtil = require('/lib/util');
 
 var viewLegacy = resolve('sumome-script.html');
 var viewModern = resolve('sumome-script-modern.html');
@@ -24,10 +23,10 @@ exports.responseProcessor = function(req, res) {
 
 		// Add it to the response source code
 		if (sumomeType === 'legacy') {
-			res.pageContributions.headEnd = libUtil.data.forceArray(res.pageContributions.headEnd);
+			res.pageContributions.headEnd = (Array.isArray(res.pageContributions.headEnd) ? res.pageContributions.headEnd : [res.pageContributions.headEnd]);
 			res.pageContributions.headEnd.push(metadata);
 		} else {
-			res.pageContributions.bodyEnd = libUtil.data.forceArray(res.pageContributions.bodyEnd);
+			res.pageContributions.bodyEnd = (Array.isArray(res.pageContributions.bodyEnd) ? res.pageContributions.bodyEnd : [res.pageContributions.bodyEnd]);
 			res.pageContributions.bodyEnd.push(metadata);
 		}
 	}


### PR DESCRIPTION
## Summary

Removes the `lib-util` dependency. The app used only `util.data.forceArray` (twice, in the SumoMe page-contribution processor); inlined as `(Array.isArray(x) ? x : [x])` per the Nashorn-safe pattern.

## Changes

- `src/main/resources/cms/processors/sumome-script.js` — drop `require('/lib/util')`, inline both `forceArray` calls.
- `build.gradle` — drop `include libs.lib.util`.
- `gradle/libs.versions.toml` — drop the `util` version and `lib-util` library entries.

## Test plan

- [x] `./gradlew build --refresh-dependencies` passes locally
- [x] Verified the built jar no longer bundles `lib-util` (grep for `lib-util` / `lib/util` in jar listing returns nothing)